### PR TITLE
Update ABC import

### DIFF
--- a/l18n/translation.py
+++ b/l18n/translation.py
@@ -2,7 +2,7 @@ import os
 import gettext
 import bisect
 from locale import getdefaultlocale
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from copy import copy, deepcopy
 
 import six


### PR DESCRIPTION
Importing the ABCs from 'collections' doesn't work in python 3.9.